### PR TITLE
Introduction of OpenSSL Updater for webOS 2.x/3.x devices (alpha version)

### DIFF
--- a/alpha-apps/openssl-updater/Makefile
+++ b/alpha-apps/openssl-updater/Makefile
@@ -3,7 +3,7 @@ TITLE	 = OpenSSL Updater
 APP_ID   = org.webosinternals.${NAME}
 SIGNER   = org.webosinternals
 BLDFLAGS = -p
-VERSION  = 0.9.8-3
+VERSION  = 0.9.8-4
 TYPE	 = Application
 CATEGORY = System Utilities
 HOMEPAGE = https://github.com/tgaillar/OpenSSL-Updater/wiki
@@ -11,6 +11,7 @@ ICON	 = https://github.com/tgaillar/OpenSSL-Updater/raw/master/icon_splash.png
 MINWEBOSVERSION = 2.0.0
 DESCRIPTION = Update system-installed OpenSSL, directly patching the binaries (not to be confused with the optware version that gets installed in /opt).<br><br>Simply uninstall this application to return your device to its original, unpatched state.<br><br><b>A system reboot is required after installation/removal, as running programs will see their OpenSSL dynamic libraries change (and most certainly crash). This is automagically performed by the end of the installation process.</b><br>
 CHANGELOG = \
+0.9.8-4: Latest OpenSSL release (OpenSSL 0.9.8zg 11 Jun 2015) with sha256WithRSAEncryption digest capability (needed for GMAIL and a few others so Root CA can be digested -- again!), libssl updated with reverse-engineered patch to match (one of never published) HP/Palm patch (at least for mojomail-eas so it can validate certificates)<br>\
 0.9.8-3: Original OpenSSL release for webOS 2.x/3.x devices (OpenSSL 0.9.8k 25 Mar 2009) with libssl reverse-engineered patch to match (one of never published) HP/Palm delivered version, a proof-of-concept to demonstrate mojomail-eas can validate certificates (Exchange Active Sync)<br>\
 0.9.8-2: Original OpenSSL release for webOS 2.x/3.x devices (OpenSSL 0.9.8k 25 Mar 2009), only to demonstrate absence of (never published) HP/Palm patch, needed at least so mojomail-eas can validate certificates (Exchange Active Sync)<br>\
 0.9.8-1: Original OpenSSL release for webOS 1.4.x devices (OpenSSL 0.9.8j 07 Jan 2009), for future investigation work in case of missing/unpublished Palm patch
@@ -67,7 +68,7 @@ include ../../support/cross-compile.mk
 build/%.built-${VERSION}: build/.unpacked-${VERSION}
 	rm -rf build/$*
 	( cd build/src/src ; \
-	  ${MAKE} realclean stage ARCH="$*" STAGING_DIR=${STAGING_DIR_$*} CROSS_COMPILE=${CROSS_COMPILE_$*} ; \
+	  ${MAKE} realclean stage ARCH="$*" STAGING_DIR=${STAGING_DIR_$*} CROSS_COMPILE=${CROSS_COMPILE_$*} CC="${CROSS_COMPILE_$*}gcc" ; \
 	)
 	mkdir -p build/$*/usr/palm/applications/${APP_ID}
 	cp -r build/src/* build/$*/usr/palm/applications/${APP_ID}/

--- a/alpha-apps/openssl-updater/Makefile
+++ b/alpha-apps/openssl-updater/Makefile
@@ -1,0 +1,96 @@
+NAME     = openssl-updater
+TITLE	 = OpenSSL Updater
+APP_ID   = org.webosinternals.${NAME}
+SIGNER   = org.webosinternals
+BLDFLAGS = -p
+VERSION  = 0.9.8-1
+TYPE	 = Application
+CATEGORY = System Utilities
+HOMEPAGE = https://github.com/tgaillar/OpenSSL-Updater/wiki
+ICON	 = https://github.com/tgaillar/OpenSSL-Updater/raw/master/icon_splash.png
+MINWEBOSVERSION = 1.4.0
+MAXWEBOSVERSION = 1.5.0
+DESCRIPTION = Update system-installed OpenSSL, directly patching the binaries (not to be confused with the optware version that gets installed in /opt).<br><br>Simply uninstall this application to return your device to its original, unpatched state.<br><br><b>A system reboot is required after installation/removal, as running programs will see their OpenSSL dynamic libraries change (and most certainly crash). This is automagically performed by the end of the installation process.</b><br>
+CHANGELOG = \
+0.9.8-1: Original OpenSSL release for webOS 1.4.x devices (OpenSSL 0.9.8j 07 Jan 2009), for future investigation work in case of missing/unpublished Palm patch
+SCREENSHOTS = [\
+\"https://github.com/tgaillar/OpenSSL-Updater/raw/master/icon_splash.png\",\
+\"https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/OpenSSL_logo.png/320px-OpenSSL_logo.png\"\
+]
+LICENSE  = GPL v2 Open Source
+
+MAINTAINER = Webos Internals <webos-internals.org>, Thibaud Gaillard <thibaud.gaillard@gmail.com>
+
+SRC_GIT = git://github.com/tgaillar/OpenSSL-Updater.git
+
+ARCH_LIST = i686 armv7 armv6
+
+.PHONY: package
+package: $(foreach arch,${ARCH_LIST},ipkgs/${APP_ID}_${VERSION}_${arch}.ipk)
+include ../../support/package.mk
+
+include ../../support/download.mk
+
+.PHONY: unpack
+unpack: build/.unpacked-${VERSION}
+
+build/.unpacked-${VERSION}: ${DL_DIR}/${NAME}-${VERSION}.tar.gz
+	rm -rf build
+	mkdir -p build/src
+	tar -C build/src -xf ${DL_DIR}/${NAME}-${VERSION}.tar.gz
+	rm -rf build/src/bin build/src/*.script
+	sed -i.orig \
+		-e 's/"title": ".*"/"title": "${TITLE}"/g' \
+		-e 's/"id": ".*"/"id": "${APP_ID}"/g' \
+		-e 's/"version": ".*"/"version": "${VERSION}"/g' \
+		build/src/appinfo.json
+	rm -f build/src/appinfo.json.orig
+	sed -i.orig \
+		-e 's/PID="org.webosinternals.openssl-updater"/PID="${APP_ID}"/g' \
+		build/src/control/postinst
+	rm -f build/src/control/postinst.orig
+	sed -i.orig \
+		-e 's/PID="org.webosinternals.openssl-updater"/PID="${APP_ID}"/g' \
+		build/src/control/prerm
+	rm -f build/src/control/prerm.orig
+	touch $@
+
+.PHONY: build
+build: build/.built-${VERSION}
+
+build/.built-${VERSION}: $(foreach arch,${ARCH_LIST},build/${arch}.built-${VERSION})
+	touch $@
+
+include ../../support/cross-compile.mk
+
+build/%.built-${VERSION}: build/.unpacked-${VERSION}
+	rm -rf build/$*
+	( cd build/src/src ; \
+	  ${MAKE} realclean stage ARCH="$*" STAGING_DIR=${STAGING_DIR_$*} CROSS_COMPILE=${CROSS_COMPILE_$*} ; \
+	)
+	mkdir -p build/$*/usr/palm/applications/${APP_ID}
+	cp -r build/src/* build/$*/usr/palm/applications/${APP_ID}/
+	rm -rf build/$*/usr/palm/applications/${APP_ID}/src
+	mkdir -p build/$*/usr/palm/applications/${APP_ID}/install/usr/bin
+	install -m 755 build/src/src/build/src/apps/openssl build/$*/usr/palm/applications/${APP_ID}/install/usr/bin
+	mkdir -p build/$*/usr/palm/applications/${APP_ID}/install/usr/lib
+	install -m 755 build/src/src/build/src/libcrypto.so.* build/$*/usr/palm/applications/${APP_ID}/install/usr/lib
+	install -m 755 build/src/src/build/src/libssl.so.* build/$*/usr/palm/applications/${APP_ID}/install/usr/lib
+	mkdir -p build/$*/usr/palm/applications/${APP_ID}/src
+	install -m 644 build/src/src/Makefile build/$*/usr/palm/applications/${APP_ID}/src
+	touch $@
+
+build/%/CONTROL/postinst:
+	rm -f $@
+	mkdir -p build/$*/CONTROL
+	install -m 0775 build/src/control/postinst build/$*/CONTROL
+	chmod ugo+x $@
+
+build/%/CONTROL/prerm:
+	rm -f $@
+	mkdir -p build/$*/CONTROL
+	install -m 0775 build/src/control/prerm build/$*/CONTROL
+	chmod ugo+x $@
+
+clobber::
+	rm -rf build

--- a/alpha-apps/openssl-updater/Makefile
+++ b/alpha-apps/openssl-updater/Makefile
@@ -3,15 +3,15 @@ TITLE	 = OpenSSL Updater
 APP_ID   = org.webosinternals.${NAME}
 SIGNER   = org.webosinternals
 BLDFLAGS = -p
-VERSION  = 0.9.8-1
+VERSION  = 0.9.8-2
 TYPE	 = Application
 CATEGORY = System Utilities
 HOMEPAGE = https://github.com/tgaillar/OpenSSL-Updater/wiki
 ICON	 = https://github.com/tgaillar/OpenSSL-Updater/raw/master/icon_splash.png
-MINWEBOSVERSION = 1.4.0
-MAXWEBOSVERSION = 1.5.0
+MINWEBOSVERSION = 2.0.0
 DESCRIPTION = Update system-installed OpenSSL, directly patching the binaries (not to be confused with the optware version that gets installed in /opt).<br><br>Simply uninstall this application to return your device to its original, unpatched state.<br><br><b>A system reboot is required after installation/removal, as running programs will see their OpenSSL dynamic libraries change (and most certainly crash). This is automagically performed by the end of the installation process.</b><br>
 CHANGELOG = \
+0.9.8-2: Original OpenSSL release for webOS 2.x/3.x devices (OpenSSL 0.9.8k 25 Mar 2009), only to demonstrate absence of (never published) HP/Palm patch, needed at least so mojomail-eas can validate certificates (Exchange Active Sync)<br>\
 0.9.8-1: Original OpenSSL release for webOS 1.4.x devices (OpenSSL 0.9.8j 07 Jan 2009), for future investigation work in case of missing/unpublished Palm patch
 SCREENSHOTS = [\
 \"https://github.com/tgaillar/OpenSSL-Updater/raw/master/icon_splash.png\",\

--- a/alpha-apps/openssl-updater/Makefile
+++ b/alpha-apps/openssl-updater/Makefile
@@ -3,7 +3,7 @@ TITLE	 = OpenSSL Updater
 APP_ID   = org.webosinternals.${NAME}
 SIGNER   = org.webosinternals
 BLDFLAGS = -p
-VERSION  = 0.9.8-4
+VERSION  = 0.9.8-5
 TYPE	 = Application
 CATEGORY = System Utilities
 HOMEPAGE = https://github.com/tgaillar/OpenSSL-Updater/wiki
@@ -11,6 +11,7 @@ ICON	 = https://github.com/tgaillar/OpenSSL-Updater/raw/master/icon_splash.png
 MINWEBOSVERSION = 2.0.0
 DESCRIPTION = Update system-installed OpenSSL, directly patching the binaries (not to be confused with the optware version that gets installed in /opt).<br><br>Simply uninstall this application to return your device to its original, unpatched state.<br><br><b>A system reboot is required after installation/removal, as running programs will see their OpenSSL dynamic libraries change (and most certainly crash). This is automagically performed by the end of the installation process.</b><br>
 CHANGELOG = \
+0.9.8-5: Forcing update installation for now (it looks like some devices -- 3.0.[45] TP -- have discrepancies between installed OpenSSL files and their reference checksum in /md5sums.gz, an OTA issue???)<br>\
 0.9.8-4: Latest OpenSSL release (OpenSSL 0.9.8zg 11 Jun 2015) with sha256WithRSAEncryption digest capability (needed for GMAIL and a few others so Root CA can be digested -- again!), libssl updated with reverse-engineered patch to match (one of never published) HP/Palm patch (at least for mojomail-eas so it can validate certificates)<br>\
 0.9.8-3: Original OpenSSL release for webOS 2.x/3.x devices (OpenSSL 0.9.8k 25 Mar 2009) with libssl reverse-engineered patch to match (one of never published) HP/Palm delivered version, a proof-of-concept to demonstrate mojomail-eas can validate certificates (Exchange Active Sync)<br>\
 0.9.8-2: Original OpenSSL release for webOS 2.x/3.x devices (OpenSSL 0.9.8k 25 Mar 2009), only to demonstrate absence of (never published) HP/Palm patch, needed at least so mojomail-eas can validate certificates (Exchange Active Sync)<br>\

--- a/alpha-apps/openssl-updater/Makefile
+++ b/alpha-apps/openssl-updater/Makefile
@@ -3,7 +3,7 @@ TITLE	 = OpenSSL Updater
 APP_ID   = org.webosinternals.${NAME}
 SIGNER   = org.webosinternals
 BLDFLAGS = -p
-VERSION  = 0.9.8-2
+VERSION  = 0.9.8-3
 TYPE	 = Application
 CATEGORY = System Utilities
 HOMEPAGE = https://github.com/tgaillar/OpenSSL-Updater/wiki
@@ -11,6 +11,7 @@ ICON	 = https://github.com/tgaillar/OpenSSL-Updater/raw/master/icon_splash.png
 MINWEBOSVERSION = 2.0.0
 DESCRIPTION = Update system-installed OpenSSL, directly patching the binaries (not to be confused with the optware version that gets installed in /opt).<br><br>Simply uninstall this application to return your device to its original, unpatched state.<br><br><b>A system reboot is required after installation/removal, as running programs will see their OpenSSL dynamic libraries change (and most certainly crash). This is automagically performed by the end of the installation process.</b><br>
 CHANGELOG = \
+0.9.8-3: Original OpenSSL release for webOS 2.x/3.x devices (OpenSSL 0.9.8k 25 Mar 2009) with libssl reverse-engineered patch to match (one of never published) HP/Palm delivered version, a proof-of-concept to demonstrate mojomail-eas can validate certificates (Exchange Active Sync)<br>\
 0.9.8-2: Original OpenSSL release for webOS 2.x/3.x devices (OpenSSL 0.9.8k 25 Mar 2009), only to demonstrate absence of (never published) HP/Palm patch, needed at least so mojomail-eas can validate certificates (Exchange Active Sync)<br>\
 0.9.8-1: Original OpenSSL release for webOS 1.4.x devices (OpenSSL 0.9.8j 07 Jan 2009), for future investigation work in case of missing/unpublished Palm patch
 SCREENSHOTS = [\


### PR DESCRIPTION
Hi Rod,

I'd like to enter the alpha program with this new application (OpenSSL-Updater) and updated the build system accordingly.

[OpenSSL Updater](https://github.com/tgaillar/openssl-updater) goal is to update the system-installed OpenSSL binaries to the latest available 0.9.8 release (0.9.8zg) and fix the dreaded "*requested encryption not supported by server*" issue that is slowly killing webOS devices (servers moving away from SHA-1, GMAIL being the most prominent one). Some patching was needed.

There's a wiki to provide more information: [https://github.com/tgaillar/OpenSSL-Updater/wiki](https://github.com/tgaillar/OpenSSL-Updater/wiki)

I did my best to make this update meet (what I understood to be) the WebOS Internals standards, but I may have missed things that will probably look obvious to you.

If you agree to it, I'll then open a dedicated thread in the webOS Nation forum to support the application ramp-up and life. The initial post would 

Is there anything else I should do?

Your feedback is more than welcome!

Thibaud