### PR TITLE
Replace palm.com urls

### DIFF
--- a/support/doctors.mk
+++ b/support/doctors.mk
@@ -1,71 +1,71 @@
 ${DOCTOR_DIR}/webosdoctorp100ueu-wr-1.4.5.jar:
 	mkdir -p ${DOCTOR_DIR}
-	curl -L -o $@ http://downloads.help.palm.com/webosdoctor/rom/pre/p145r0d06302010/eudep145rod/webosdoctorp100ueu-wr.jar
+	curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/pre/p145r0d06302010/eudep145rod/webosdoctorp100ueu-wr.jar
 
 ${DOCTOR_DIR}/webosdoctorp121ewweu-wr-1.4.5.jar:
 	mkdir -p ${DOCTOR_DIR}
-	curl -L -o $@ http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px145r0d06302010/wrep145rod/webosdoctorp121ewweu-wr.jar
+	curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/pixiplus/px145r0d06302010/wrep145rod/webosdoctorp121ewweu-wr.jar
 
 ${DOCTOR_DIR}/webosdoctorp101ewwverizonwireless-1.4.5.1.jar:
 	mkdir -p ${DOCTOR_DIR}
-	curl -L -o $@ http://downloads.help.palm.com/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar
+	curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar
 
-${DOCTOR_DIR}/webosdoctorp121ewwverizonwireless-1.4.5.1.jar:
+${DOCTOR_DIR}doctor/webosdoctorp121ewwverizonwireless-1.4.5.1.jar:
 	mkdir -p ${DOCTOR_DIR}
-	curl -L -o $@ http://downloads.help.palm.com/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar
+	curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/pixiplus/px1451r0d05182011/ver1z0np1451rod/webosdoctorp121ewwverizonwireless.jar
 
 ${DOCTOR_DIR}/webosdoctorp103ueu-wr-2.0.0.jar:
 	mkdir -p ${DOCTOR_DIR}
-	curl -L -o $@ http://downloads.help.palm.com/webosdoctor/rom/pre2/p20r0d11182010/wrep20rod/webosdoctorp103ueu-wr.jar
+	curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/pre2/p20r0d11182010/wrep20rod/webosdoctorp103ueu-wr.jar
 
 ${DOCTOR_DIR}/webosdoctorp102ueuna-wr-2.0.1.jar:
 	mkdir -p ${DOCTOR_DIR}
-	curl -L -o $@ http://downloads.help.palm.com/webosdoctor/rom/pre2/p201r0d11242010/wrep201rod/webosdoctorp102ueuna-wr.jar
+	curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/pre2/p201r0d11242010/wrep201rod/webosdoctorp102ueuna-wr.jar
 
 ${DOCTOR_DIR}/webosdoctorp101ueu-wr-2.1.0.jar:
 	mkdir -p ${DOCTOR_DIR}
-	curl -L -o $@ http://downloads.help.palm.com/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar
+	curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar
 
 ${DOCTOR_DIR}/webosdoctorp103ueuna-wr-2.1.0.jar:
 	mkdir -p ${DOCTOR_DIR}
-	curl -L -o $@ http://downloads.help.palm.com/webosdoctor/rom/pre2/p210sfr03082011/wrep210rod/webosdoctorp103ueuna-wr.jar
+	curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/pre2/p210sfr03082011/wrep210rod/webosdoctorp103ueuna-wr.jar
 
 ${DOCTOR_DIR}/webosdoctorp160una-wr-2.1.1.jar:
 	mkdir -p ${DOCTOR_DIR}
-	curl -L -o $@ http://downloads.help.palm.com/webosdoctor/rom/veer/p211r0d06292011/wrp211rod/webosdoctorp160unawr.jar
+	curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/veer/p211r0d06292011/wrp211rod/webosdoctorp160unawr.jar
 
 ${DOCTOR_DIR}/webosdoctorp160unaatt-2.1.2.jar:
 	mkdir -p ${DOCTOR_DIR}
-	curl -L -o $@ http://downloads.help.palm.com/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar
+	curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar
 
 ${DOCTOR_DIR}/webosdoctorp220manta-wr-2.2.0.jar:
 	mkdir -p ${DOCTOR_DIR}
-	curl -L -o $@ http://downloads.help.palm.com/webosdoctor/rom/manta/p220r0d08222011/wdmantarow/webosdoctorp220mantawr.jar
+	curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/manta/p220r0d08222011/wdmantarow/webosdoctorp220mantawr.jar
 
 ${DOCTOR_DIR}/webosdoctorp223mantaatt-2.2.3.jar:
 	mkdir -p ${DOCTOR_DIR}
-	curl -L -o $@ http://downloads.help.palm.com/webosdoctor/rom/manta/p223r0d09272011/wdmantaatt/webosdoctorp223mantaatt.jar
+	curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/manta/p223r0d09272011/wdmantaatt/webosdoctorp223mantaatt.jar
 
 ${DOCTOR_DIR}/webosdoctorp224pre2-wr-2.2.4.jar:
 	mkdir -p ${DOCTOR_DIR}
-	curl -L -o $@ http://downloads.help.palm.com/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar
+	curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar
 
 ${DOCTOR_DIR}/webosdoctorp224manta-wr-2.2.4.jar:
 	mkdir -p ${DOCTOR_DIR}
-	curl -L -o $@ http://downloads.help.palm.com/webosdoctor/rom/manta/p224r0d12192011/wdmantawr/webosdoctorp224mantawr.jar
+	curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/manta/p224r0d12192011/wdmantawr/webosdoctorp224mantawr.jar
 
 ${DOCTOR_DIR}/webosdoctorp300hstnhwifi-3.0.0.jar:
 	mkdir -p ${DOCTOR_DIR}
-	curl -L -o $@ http://downloads.help.palm.com/webosdoctor/rom/touchpad/wd300wifi/webosdoctorp300hstnhwifi.jar
+	curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/touchpad/wd300wifi/webosdoctorp300hstnhwifi.jar
 
 ${DOCTOR_DIR}/webosdoctorp302hstnhwifi-3.0.2.jar:
 	mkdir -p ${DOCTOR_DIR}
-	curl -L -o $@ http://downloads.help.palm.com/webosdoctor/rom/touchpad/p302r0d08012011/wifip302rod/webosdoctorp302hstnhwifi.jar
+	curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/touchpad/p302r0d08012011/wifip302rod/webosdoctorp302hstnhwifi.jar
 
 ${DOCTOR_DIR}/webosdoctorp304hstnhwifi-3.0.4.jar:
 	mkdir -p ${DOCTOR_DIR}
-	curl -L -o $@ http://downloads.help.palm.com/webosdoctor/rom/touchpad/p304rod10182011/wd304wifi/webosdoctorp304hstnhwifi.jar
+	curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/touchpad/p304rod10182011/wd304wifi/webosdoctorp304hstnhwifi.jar
 
 ${DOCTOR_DIR}/webosdoctorp305hstnhwifi-3.0.5.jar:
 	mkdir -p ${DOCTOR_DIR}
-	curl -L -o $@ http://downloads.help.palm.com/webosdoctor/rom/touchpad/p305rod01122012/wd305wifi/webosdoctorp305hstnhwifi.jar
+	curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/touchpad/p305rod01122012/wd305wifi/webosdoctorp305hstnhwifi.jar

--- a/support/ipkg-info.mk
+++ b/support/ipkg-info.mk
@@ -21,7 +21,7 @@ ${DOCTOR_DIR}/webosdoctor-1.4.5.jar:
 	if [ -e ${DOCTOR_DIR}/webosdoctorp100ueu-wr-1.4.5.jar ] ; then \
 	  ln -s webosdoctorp100ueu-wr-1.4.5.jar $@ ; \
 	else \
-	  curl -L -o $@ http://downloads.help.palm.com/rom/pre/p145r0d06302010/eudep145rod/webosdoctorp100ueu-wr.jar; \
+	  curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/pre/p145r0d06302010/eudep145rod/webosdoctorp100ueu-wr.jar; \
 	fi
 
 ${DOCTOR_DIR}/webosdoctor-1.4.5.1.jar:
@@ -29,7 +29,7 @@ ${DOCTOR_DIR}/webosdoctor-1.4.5.1.jar:
 	if [ -e ${DOCTOR_DIR}/webosdoctorp101ewwverizonwireless-1.4.5.1.jar ] ; then \
 	  ln -s webosdoctorp101ewwverizonwireless-1.4.5.1.jar $@ ; \
 	else \
-	  curl -L -o $@ http://downloads.help.palm.com/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar; \
+	  curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/preplus/p1451r0d05182011/ver1z0np1451rod/webosdoctorp101ewwverizonwireless.jar; \
 	fi
 
 ${DOCTOR_DIR}/webosdoctor-2.0.0.jar:
@@ -37,7 +37,7 @@ ${DOCTOR_DIR}/webosdoctor-2.0.0.jar:
 	if [ -e ${DOCTOR_DIR}/webosdoctorp103ueu-wr-2.0.0.jar ] ; then \
 	  ln -s webosdoctorp103ueu-wr-2.0.0.jar $@ ; \
 	else \
-	  curl -L -o $@ http://downloads.help.palm.com/rom/pre2/p20r0d11182010/wrep20rod/webosdoctorp103ueu-wr.jar; \
+	  curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/pre2/p20r0d11182010/wrep20rod/webosdoctorp103ueu-wr.jar; \
 	fi
 
 ${DOCTOR_DIR}/webosdoctor-2.0.1.jar:
@@ -45,7 +45,7 @@ ${DOCTOR_DIR}/webosdoctor-2.0.1.jar:
 	if [ -e ${DOCTOR_DIR}/webosdoctorp102ueuna-wr-2.0.1.jar ] ; then \
 	  ln -s webosdoctorp102ueuna-wr-2.0.1.jar $@ ; \
 	else \
-	  curl -L -o $@ http://downloads.help.palm.com/rom/pre2/p201r0d11242010/wrep201rod/webosdoctorp102ueuna-wr.jar; \
+	  curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/pre2/p201r0d11242010/wrep201rod/webosdoctorp102ueuna-wr.jar; \
 	fi
 
 ${DOCTOR_DIR}/webosdoctor-2.1.0.jar:
@@ -53,7 +53,7 @@ ${DOCTOR_DIR}/webosdoctor-2.1.0.jar:
 	if [ -e ${DOCTOR_DIR}/webosdoctorp101ueu-wr-2.1.0.jar ] ; then \
 	  ln -s webosdoctorp101ueu-wr-2.1.0.jar $@ ; \
 	else \
-	  curl -L -o $@ http://downloads.help.palm.com/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar; \
+	  curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/preplus/p210r0d03142011/eudep210rod/webosdoctorp101ueu-wr.jar; \
 	fi
 
 ${DOCTOR_DIR}/webosdoctor-2.1.1.jar:
@@ -61,7 +61,7 @@ ${DOCTOR_DIR}/webosdoctor-2.1.1.jar:
 	if [ -e ${DOCTOR_DIR}/webosdoctorp160una-wr-2.1.1.jar ] ; then \
 	  ln -s webosdoctorp160una-wr-2.1.1.jar $@ ; \
 	else \
-	  curl -L -o $@ http://downloads.help.palm.com/rom/veer/p211r0d06292011/wrp211rod/webosdoctorp160unawr.jar; \
+	  curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/veer/p211r0d06292011/wrp211rod/webosdoctorp160unawr.jar; \
 	fi
 
 ${DOCTOR_DIR}/webosdoctor-2.1.2.jar:
@@ -69,7 +69,7 @@ ${DOCTOR_DIR}/webosdoctor-2.1.2.jar:
 	if [ -e ${DOCTOR_DIR}/webosdoctorp160unaatt-2.1.2.jar ] ; then \
 	  ln -s webosdoctorp160unaatt-2.1.2.jar $@ ; \
 	else \
-	  curl -L -o $@ http://downloads.help.palm.com/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar; \
+	  curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/veer/p212r0d05132011/attp212rod/webosdoctorp160unaatt.jar; \
 	fi
 
 ${DOCTOR_DIR}/webosdoctor-2.2.0.jar:
@@ -77,7 +77,7 @@ ${DOCTOR_DIR}/webosdoctor-2.2.0.jar:
 	if [ -e ${DOCTOR_DIR}/webosdoctorp220manta-wr-2.2.0.jar ] ; then \
 	  ln -s webosdoctorp220manta-wr-2.2.0.jar $@ ; \
 	else \
-	  curl -L -o $@ http://downloads.help.palm.com/rom/manta/p220r0d08222011/wdmantarow/webosdoctorp220mantawr.jar; \
+	  curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/manta/p220r0d08222011/wdmantarow/webosdoctorp220mantawr.jar; \
 	fi
 
 ${DOCTOR_DIR}/webosdoctor-2.2.3.jar:
@@ -85,7 +85,7 @@ ${DOCTOR_DIR}/webosdoctor-2.2.3.jar:
 	if [ -e ${DOCTOR_DIR}/webosdoctorp223mantaatt-2.2.3.jar ] ; then \
 	  ln -s webosdoctorp223mantaatt-2.2.3.jar $@ ; \
 	else \
-	  curl -L -o $@ http://downloads.help.palm.com/rom/manta/p223r0d09272011/wdmantaatt/webosdoctorp223mantaatt.jar; \
+	  curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/manta/p223r0d09272011/wdmantaatt/webosdoctorp223mantaatt.jar; \
 	fi
 
 ${DOCTOR_DIR}/webosdoctor-2.2.4.jar:
@@ -93,7 +93,7 @@ ${DOCTOR_DIR}/webosdoctor-2.2.4.jar:
 	if [ -e ${DOCTOR_DIR}/webosdoctorp224pre2-wr-2.2.4.jar ] ; then \
 	  ln -s webosdoctorp224pre2-wr-2.2.4.jar $@ ; \
 	else \
-	  curl -L -o $@ http://downloads.help.palm.com/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar; \
+	  curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/pre2/p224rod12052011/wrep224rod/webosdoctorp224pre2wr.jar; \
 	fi
 
 ${DOCTOR_DIR}/webosdoctor-3.0.0.jar:
@@ -101,7 +101,7 @@ ${DOCTOR_DIR}/webosdoctor-3.0.0.jar:
 	if [ -e ${DOCTOR_DIR}/webosdoctorp300hstnhwifi-3.0.0.jar ] ; then \
 	  ln -s webosdoctorp300hstnhwifi-3.0.0.jar $@ ; \
 	else \
-	  curl -L -o $@ http://downloads.help.palm.com/rom/touchpad/wd300wifi/webosdoctorp300hstnhwifi.jar; \
+	  curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/touchpad/wd300wifi/webosdoctorp300hstnhwifi.jar; \
 	fi
 
 ${DOCTOR_DIR}/webosdoctor-3.0.2.jar:
@@ -109,7 +109,7 @@ ${DOCTOR_DIR}/webosdoctor-3.0.2.jar:
 	if [ -e ${DOCTOR_DIR}/webosdoctorp302hstnhwifi-3.0.2.jar ] ; then \
 	  ln -s webosdoctorp302hstnhwifi-3.0.2.jar $@ ; \
 	else \
-	  curl -L -o $@ http://downloads.help.palm.com/rom/touchpad/p302r0d08012011/wifip302rod/webosdoctorp302hstnhwifi.jar; \
+	  curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/touchpad/p302r0d08012011/wifip302rod/webosdoctorp302hstnhwifi.jar; \
 	fi
 
 ${DOCTOR_DIR}/webosdoctor-3.0.4.jar:
@@ -117,7 +117,7 @@ ${DOCTOR_DIR}/webosdoctor-3.0.4.jar:
 	if [ -e ${DOCTOR_DIR}/webosdoctorp304hstnhwifi-3.0.4.jar ] ; then \
 	  ln -s webosdoctorp304hstnhwifi-3.0.4.jar $@ ; \
 	else \
-	  curl -L -o $@ http://downloads.help.palm.com/rom/touchpad/p304rod10182011/wd304wifi/webosdoctorp304hstnhwifi.jar; \
+	  curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/touchpad/p304rod10182011/wd304wifi/webosdoctorp304hstnhwifi.jar; \
 	fi
 
 ${DOCTOR_DIR}/webosdoctor-3.0.5.jar:
@@ -125,5 +125,5 @@ ${DOCTOR_DIR}/webosdoctor-3.0.5.jar:
 	if [ -e ${DOCTOR_DIR}/webosdoctorp305hstnhwifi-3.0.5.jar ] ; then \
 	  ln -s webosdoctorp305hstnhwifi-3.0.5.jar $@ ; \
 	else \
-	  curl -L -o $@ http://downloads.help.palm.com/rom/touchpad/p305rod01122012/wd305wifi/webosdoctorp305hstnhwifi.jar; \
+	  curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/touchpad/p305rod01122012/wd305wifi/webosdoctorp305hstnhwifi.jar; \
 	fi

--- a/support/kernel.mk
+++ b/support/kernel.mk
@@ -23,7 +23,7 @@ WEBOS_VERSIONS = 2.1.1 2.1.2
 KERNEL_VERSION = 2.6.29
 endif
 ifeq ("${DEVICE}","touchpad")
-WEBOS_VERSIONS = 3.0.2 3.0.4
+WEBOS_VERSIONS = 3.0.0 3.0.2 3.0.4 3.0.5
 KERNEL_VERSION = 2.6.35
 endif
 ifeq ("${DEVICE}","pre3")
@@ -34,7 +34,7 @@ ifeq ("${DEVICE}","opal")
 WEBOS_VERSIONS = 3.0.3
 KERNEL_VERSION = 2.6.35
 endif
-KERNEL_SOURCE = http://downloads.help.palm.com/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.tgz
+KERNEL_SOURCE = http://sources.nslu2-linux.org/sources/webos-sources/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.tgz
 DL_DIR = ../../downloads
 POSTINSTALLFLAGS = RestartDevice
 POSTUPDATEFLAGS  = RestartDevice
@@ -188,16 +188,16 @@ endif
 COMPATIBLE_VERSIONS = ${WEBOS_VERSION}
 
 ifeq ("${WEBOS_VERSION}", "1.4.5")
-KERNEL_PATCH  = http://downloads.help.palm.com/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}-patch\(${DEVICE}\).gz
+KERNEL_PATCH  = http://sources.nslu2-linux.org/sources/webos-sources/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}-patch\(${DEVICE}\).gz
 endif
 
 ifeq ("${WEBOS_VERSION}", "1.4.5.1")
-KERNEL_PATCH  = http://downloads.help.palm.com/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}-patch\(${DEVICE}\).gz
+KERNEL_PATCH  = http://sources.nslu2-linux.org/sources/webos-sources/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}-patch\(${DEVICE}\).gz
 endif
 
 ifeq ("${WEBOS_VERSION}", "2.0.0")
 ifeq ("${DEVICE}","pre2")
-KERNEL_PATCH = http://downloads.help.palm.com/opensource/2.0.0/kernel_patches.tar.gz
+KERNEL_PATCH = http://sources.nslu2-linux.org/sources/webos-sources/opensource/2.0.0/kernel_patches.tar.gz
 KERNEL_SUBMISSION = patch-submission-48
 endif
 # Override the compiler
@@ -206,8 +206,8 @@ endif
 
 ifeq ("${WEBOS_VERSION}", "2.0.1")
 ifeq ("${DEVICE}","pre2")
-KERNEL_SOURCE = http://downloads.help.palm.com/opensource/2.0.0/linuxkernel-${KERNEL_VERSION}.tgz
-KERNEL_PATCH = http://downloads.help.palm.com/opensource/2.0.0/kernel_patches.tar.gz
+KERNEL_SOURCE = http://sources.nslu2-linux.org/sources/webos-sources/opensource/2.0.0/linuxkernel-${KERNEL_VERSION}.tgz
+KERNEL_PATCH = http://sources.nslu2-linux.org/sources/webos-sources/opensource/2.0.0/kernel_patches.tar.gz
 KERNEL_SUBMISSION = patch-submission-54
 endif
 # Override the compiler
@@ -217,11 +217,11 @@ endif
 ifeq ("${WEBOS_VERSION}", "2.1.0")
 ifeq ("${DEVICE}","pre")
 COMPATIBLE_VERSIONS = 2.1.0 | 2.2.4
-KERNEL_PATCH = http://downloads.help.palm.com/opensource/2.1.0/linuxkernel-2.6.24.preplus.2-1-0.patch.tgz
+KERNEL_PATCH = http://sources.nslu2-linux.org/sources/webos-sources/opensource/2.1.0/linuxkernel-2.6.24.preplus.2-1-0.patch.tgz
 KERNEL_SUBMISSION = linuxkernel-2.6.24.patch
 endif
 ifeq ("${DEVICE}","pre2")
-KERNEL_PATCH = http://downloads.help.palm.com/opensource/2.1.0/linuxkernel-2.6.24.pre2.2-1-0.patch.tgz
+KERNEL_PATCH = http://sources.nslu2-linux.org/sources/webos-sources/opensource/2.1.0/linuxkernel-2.6.24.pre2.2-1-0.patch.tgz
 KERNEL_SUBMISSION = linuxkernel-2.6.24.patch
 endif
 # Override the compiler
@@ -231,7 +231,7 @@ endif
 ifeq ("${WEBOS_VERSION}", "2.1.1")
 ifeq ("${DEVICE}","veer")
 COMPATIBLE_VERSIONS = 2.1.1
-KERNEL_PATCH  = http://downloads.help.palm.com/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.patch.tgz
+KERNEL_PATCH  = http://sources.nslu2-linux.org/sources/webos-sources/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.patch.tgz
 KERNEL_SUBMISSION = linuxkernel-${KERNEL_VERSION}.patch/kerneldiffs.txt
 # Override the compiler
 CROSS_COMPILE_arm = $(shell cd ../.. ; pwd)/toolchain/cs09q1armel/build/arm-2009q1/bin/arm-none-linux-gnueabi-
@@ -241,7 +241,7 @@ endif
 ifeq ("${WEBOS_VERSION}", "2.1.2")
 ifeq ("${DEVICE}","veer")
 COMPATIBLE_VERSIONS = 2.1.2 | 2.2.1
-KERNEL_PATCH  = http://downloads.help.palm.com/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.patch.tgz
+KERNEL_PATCH  = http://sources.nslu2-linux.org/sources/webos-sources/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.patch.tgz
 KERNEL_SUBMISSION = linuxkernel-${KERNEL_VERSION}.patch/kerneldiffs.txt
 # Override the compiler
 CROSS_COMPILE_arm = $(shell cd ../.. ; pwd)/toolchain/cs09q1armel/build/arm-2009q1/bin/arm-none-linux-gnueabi-
@@ -251,8 +251,8 @@ endif
 ifeq ("${WEBOS_VERSION}", "2.2.0")
 ifeq ("${DEVICE}","pre3")
 COMPATIBLE_VERSIONS = 2.2.0
-KERNEL_SOURCE = http://downloads.help.palm.com/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.tar.gz
-KERNEL_PATCH  = http://downloads.help.palm.com/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.patch.tar.gz
+KERNEL_SOURCE = http://sources.nslu2-linux.org/sources/webos-sources/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.tar.gz
+KERNEL_PATCH  = http://sources.nslu2-linux.org/sources/webos-sources/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.patch.tar.gz
 KERNEL_SUBMISSION = kernelpatch-2.2.0.txt
 # Override the compiler
 CROSS_COMPILE_arm = $(shell cd ../.. ; pwd)/toolchain/cs09q1armel/build/arm-2009q1/bin/arm-none-linux-gnueabi-
@@ -262,8 +262,8 @@ endif
 ifeq ("${WEBOS_VERSION}", "2.2.3")
 ifeq ("${DEVICE}","pre3")
 COMPATIBLE_VERSIONS = 2.2.3
-KERNEL_SOURCE = http://downloads.help.palm.com/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.tar.gz
-KERNEL_PATCH  = http://downloads.help.palm.com/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.patch.tar.gz
+KERNEL_SOURCE = http://sources.nslu2-linux.org/sources/webos-sources/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.tar.gz
+KERNEL_PATCH  = http://sources.nslu2-linux.org/sources/webos-sources/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.patch.tar.gz
 KERNEL_SUBMISSION = kernelpatches-2.2.3.txt
 # Override the compiler
 CROSS_COMPILE_arm = $(shell cd ../.. ; pwd)/toolchain/cs09q1armel/build/arm-2009q1/bin/arm-none-linux-gnueabi-
@@ -273,15 +273,15 @@ endif
 ifeq ("${WEBOS_VERSION}", "2.2.4")
 ifeq ("${DEVICE}","pre2")
 COMPATIBLE_VERSIONS = 2.2.4
-# KERNEL_SOURCE = http://downloads.help.palm.com/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.tar.gz
-KERNEL_SOURCE = http://downloads.help.palm.com/opensource/2.1.0/linuxkernel-${KERNEL_VERSION}.tar.gz
-KERNEL_PATCH  = http://downloads.help.palm.com/opensource/${WEBOS_VERSION}/kernelpatch-${WEBOS_VERSION}-${DEVICE}.tgz
+# KERNEL_SOURCE = http://sources.nslu2-linux.org/sources/webos-sources/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.tar.gz
+KERNEL_SOURCE = http://sources.nslu2-linux.org/sources/webos-sources/opensource/2.1.0/linuxkernel-${KERNEL_VERSION}.tar.gz
+KERNEL_PATCH  = http://sources.nslu2-linux.org/sources/webos-sources/opensource/${WEBOS_VERSION}/kernelpatch-${WEBOS_VERSION}-${DEVICE}.tgz
 KERNEL_SUBMISSION = kernel-${WEBOS_VERSION}.txt
 endif
 ifeq ("${DEVICE}","pre3")
 COMPATIBLE_VERSIONS = 2.2.4
-KERNEL_SOURCE = http://downloads.help.palm.com/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.tar.gz
-KERNEL_PATCH  = http://downloads.help.palm.com/opensource/${WEBOS_VERSION}/kernelpatch-${WEBOS_VERSION}-${DEVICE}.tgz
+KERNEL_SOURCE = http://sources.nslu2-linux.org/sources/webos-sources/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.tar.gz
+KERNEL_PATCH  = http://sources.nslu2-linux.org/sources/webos-sources/opensource/${WEBOS_VERSION}/kernelpatch-${WEBOS_VERSION}-${DEVICE}.tgz
 KERNEL_SUBMISSION = kernel-${WEBOS_VERSION}.txt
 endif
 # Override the compiler
@@ -291,7 +291,7 @@ endif
 ifeq ("${WEBOS_VERSION}", "3.0.0")
 ifeq ("${DEVICE}","touchpad")
 COMPATIBLE_VERSIONS = 3.0.0
-KERNEL_PATCH  = http://downloads.help.palm.com/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.patch.tgz
+KERNEL_PATCH  = http://sources.nslu2-linux.org/sources/webos-sources/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.patch.tgz
 KERNEL_SUBMISSION = kernelpatch-3.0.0.txt
 # Override the compiler
 CROSS_COMPILE_arm = $(shell cd ../.. ; pwd)/toolchain/cs09q1armel/build/arm-2009q1/bin/arm-none-linux-gnueabi-
@@ -301,7 +301,7 @@ endif
 ifeq ("${WEBOS_VERSION}", "3.0.2")
 ifeq ("${DEVICE}","touchpad")
 COMPATIBLE_VERSIONS = 3.0.2
-KERNEL_PATCH  = http://downloads.help.palm.com/opensource/3.0.2/linuxkernel-${KERNEL_VERSION}.patches.tgz
+KERNEL_PATCH  = http://sources.nslu2-linux.org/sources/webos-sources/opensource/3.0.2/linuxkernel-${KERNEL_VERSION}.patches.tgz
 KERNEL_SUBMISSION = kernelpatch-3.0.2.txt
 # Override the compiler
 CROSS_COMPILE_arm = $(shell cd ../.. ; pwd)/toolchain/cs09q1armel/build/arm-2009q1/bin/arm-none-linux-gnueabi-
@@ -321,7 +321,7 @@ endif
 ifeq ("${WEBOS_VERSION}", "3.0.4")
 ifeq ("${DEVICE}","touchpad")
 COMPATIBLE_VERSIONS = 3.0.4
-KERNEL_PATCH  = http://downloads.help.palm.com/opensource/3.0.4/linuxkernel-${KERNEL_VERSION}.patches.tgz
+KERNEL_PATCH  = http://sources.nslu2-linux.org/sources/webos-sources/opensource/3.0.4/linuxkernel-${KERNEL_VERSION}.patches.tgz
 KERNEL_SUBMISSION = kernel-3.0.4.txt
 # Override the compiler
 CROSS_COMPILE_arm = $(shell cd ../.. ; pwd)/toolchain/cs09q1armel/build/arm-2009q1/bin/arm-none-linux-gnueabi-
@@ -331,7 +331,7 @@ endif
 ifeq ("${WEBOS_VERSION}", "3.0.5")
 ifeq ("${DEVICE}","touchpad")
 COMPATIBLE_VERSIONS = 3.0.5
-KERNEL_PATCH  = http://downloads.help.palm.com/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.patch.tar.gz
+KERNEL_PATCH  = http://sources.nslu2-linux.org/sources/webos-sources/opensource/${WEBOS_VERSION}/linuxkernel-${KERNEL_VERSION}.patch.tar.gz
 KERNEL_SUBMISSION = kernel-3.0.5.txt
 # Override the compiler
 CROSS_COMPILE_arm = $(shell cd ../.. ; pwd)/toolchain/cs09q1armel/build/arm-2009q1/bin/arm-none-linux-gnueabi-

--- a/support/patch-md5sums.mk
+++ b/support/patch-md5sums.mk
@@ -13,4 +13,4 @@ build/md5sums: ${DOCTOR_DIR}/webosdoctorp100ewwsprint.jar
 ${DOCTOR_DIR}/webosdoctorp100ewwsprint.jar :
 	mkdir -p ${DOCTOR_DIR}
 	#curl -L -o $@ http://downloads.help.palm.com/rom/pre_p100eww/webosdoctorp100ewwsprint.jar
-	curl -L -o $@ http://downloads.help.palm.com/rom/ash994djslspam356z/s2x56ydt/webosdoctorp100ewwsprint.jar
+	curl -L --header 'Host: palm.cdnetworks.net' -o $@ http://195.22.200.42/webosdoctor/rom/pre/p14r0d02252010/sr1ntp140rod/webosdoctorp100ewwsprint.jar

--- a/support/service-jars.mk
+++ b/support/service-jars.mk
@@ -15,5 +15,5 @@ ${DOCTOR_DIR}/webosdoctor-1.4.0.jar:
 	if [ -e ${DOCTOR_DIR}/webosdoctorp100ewwsprint-1.4.0.jar ] ; then \
 	  ln -s webosdoctorp100ewwsprint-1.4.0.jar $@ ; \
 	else \
-	  curl -L -o $@ http://downloads.help.palm.com/rom/pre/p14r0d02252010/sr1ntp140rod/webosdoctorp100ewwsprint.jar; \
+	  curl -L --header 'Host: downloads.help.palm.com' -o $@ http://195.22.200.42/webosdoctor/rom/pre/p14r0d02252010/sr1ntp140rod/webosdoctorp100ewwsprint.jar; \
 	fi

--- a/toolchain/alsa-lib/Makefile
+++ b/toolchain/alsa-lib/Makefile
@@ -5,7 +5,7 @@ SRC_VER  = 1.0.18
 VERSION  = 1.0.18-2
 MAINTAINER = WebOS Internals <support@webos-internals.org>
 
-SRC_TGZ = http://downloads.help.palm.com/opensource/2.1.2/${NAME}-${SRC_VER}.tgz
+SRC_TGZ = http://sources.nslu2-linux.org/sources/webos-sources/opensource/2.1.2/${NAME}-${SRC_VER}.tgz
 
 .PHONY: package
 package: build/.built-${VERSION}
@@ -33,7 +33,7 @@ build/.unpacked-${VERSION}: ${DL_DIR}/${NAME}-${VERSION}.tar.gz
 	mkdir -p build/armv6 build/armv7 build/i686
 	tar -C build -z -x -f $<
 	mv build/${NAME}-${SRC_VER} build/src
-	${MAKE} SRC_FILE=http://downloads.help.palm.com/opensource/2.1.2/${NAME}-${SRC_VER}-patch.gz \
+	${MAKE} SRC_FILE=http://sources.nslu2-linux.org/sources/webos-sources/opensource/2.1.2/${NAME}-${SRC_VER}-patch.gz \
 		LOCAL_FILE=${NAME}-${VERSION}-patch.gz download
 	#cd build/src; cat ../../${DL_DIR}/${NAME}-${VERSION}-patch.gz | gunzip | patch -p0
 	touch $@

--- a/toolchain/expat/Makefile
+++ b/toolchain/expat/Makefile
@@ -5,7 +5,7 @@ SRC_VER  = 1.95.8
 VERSION  = 1.95.8-1
 MAINTAINER = WebOS Internals <support@webos-internals.org>
 
-SRC_TGZ = http://downloads.help.palm.com/opensource/2.2.4/${NAME}-${SRC_VER}.tar.gz
+SRC_TGZ = http://sources.nslu2-linux.org/sources/webos-sources/opensource/2.2.4/${NAME}-${SRC_VER}.tar.gz
 
 .PHONY: package
 package: build/.built-${VERSION}

--- a/toolchain/freetype/Makefile
+++ b/toolchain/freetype/Makefile
@@ -5,7 +5,7 @@ SRC_VER  = 2.3.12
 VERSION  = 2.3.12-2
 MAINTAINER = WebOS Internals <support@webos-internals.org>
 
-SRC_BZ2 = http://downloads.help.palm.com/opensource/3.0.0/${NAME}-${SRC_VER}.tar.bz2
+SRC_BZ2 = http://sources.nslu2-linux.org/sources/webos-sources/opensource/3.0.0/${NAME}-${SRC_VER}.tar.bz2
 
 .PHONY: package
 package: build/.built-${VERSION}
@@ -33,7 +33,7 @@ build/.unpacked-${VERSION}: ${DL_DIR}/${NAME}-${VERSION}.tar.bz2
 	mkdir -p build/armv6 build/armv7 build/i686
 	tar -C build -j -x -f $<
 	mv build/${NAME}-${SRC_VER} build/src
-	${MAKE} SRC_FILE=http://downloads.help.palm.com/opensource/3.0.0/${NAME}-${SRC_VER}-patches.tgz \
+	${MAKE} SRC_FILE=http://sources.nslu2-linux.org/sources/webos-sources/opensource/3.0.0/${NAME}-${SRC_VER}-patches.tgz \
 		LOCAL_FILE=${NAME}-${VERSION}-patches.tgz download
 	tar -x -f ${DL_DIR}/${NAME}-${VERSION}-patches.tgz -O \
 		fix-configure.patch libtool-tag.patch files/no-hardcode.patch | patch -d build/src -p1

--- a/toolchain/fuse/Makefile
+++ b/toolchain/fuse/Makefile
@@ -5,7 +5,7 @@ SRC_VER  = 2.7.2
 VERSION  = 2.7.2
 MAINTAINER = WebOS Internals <support@webos-internals.org>
 
-SRC_TGZ = http://downloads.help.palm.com/opensource/1.4.5/${NAME}-${VERSION}.tar.gz
+SRC_TGZ = http://sources.nslu2-linux.org/sources/webos-sources/opensource/1.4.5/${NAME}-${VERSION}.tar.gz
 
 .PHONY: package
 package: build/.built-${VERSION}
@@ -33,7 +33,7 @@ build/.unpacked-${VERSION}: ${DL_DIR}/${NAME}-${VERSION}.tar.gz
 	mkdir -p build/armv6 build/armv7 build/i686
 	tar -C build -z -x -f $<
 	mv build/${NAME}-${SRC_VER} build/src
-	${MAKE} SRC_FILE=http://downloads.help.palm.com/opensource/1.4.5/${NAME}-${VERSION}-patches.tgz \
+	${MAKE} SRC_FILE=http://sources.nslu2-linux.org/sources/webos-sources/opensource/1.4.5/${NAME}-${VERSION}-patches.tgz \
 		LOCAL_FILE=${NAME}-${VERSION}-patches.tgz download
 	cd build/src; tar -O -x -f ../../${DL_DIR}/${NAME}-${VERSION}-patches.tgz | patch -p1
 	touch $@

--- a/toolchain/gdbm/Makefile
+++ b/toolchain/gdbm/Makefile
@@ -5,7 +5,7 @@ SRC_VER  = 1.8.3
 VERSION  = 1.8.3-2
 MAINTAINER = WebOS Internals <support@webos-internals.org>
 
-SRC_TGZ = http://downloads.help.palm.com/opensource/2.1.2/${NAME}-${SRC_VER}.tar.gz
+SRC_TGZ = http://sources.nslu2-linux.org/sources/webos-sources/opensource/2.1.2/${NAME}-${SRC_VER}.tar.gz
 
 .PHONY: package
 package: build/.built-${VERSION}
@@ -33,7 +33,7 @@ build/.unpacked-${VERSION}: ${DL_DIR}/${NAME}-${VERSION}.tar.gz
 	mkdir -p build/armv6 build/armv7 build/i686
 	tar -C build -z -x -f $<
 	mv build/${NAME}-${SRC_VER} build/src
-	${MAKE} SRC_FILE=http://downloads.help.palm.com/opensource/2.1.2/${NAME}-${SRC_VER}-patches.tgz \
+	${MAKE} SRC_FILE=http://sources.nslu2-linux.org/sources/webos-sources/opensource/2.1.2/${NAME}-${SRC_VER}-patches.tgz \
 		LOCAL_FILE=${NAME}-${SRC_VER}-patches.tgz download
 	tar -x -f ${DL_DIR}/${NAME}-${VERSION}-patches.tgz -O \
 		libtool-mode.patch makefile.patch notimestamp.patch | patch -d build/src -p1

--- a/toolchain/jpeg/Makefile
+++ b/toolchain/jpeg/Makefile
@@ -5,7 +5,7 @@ SRC_VER  = 6.2
 VERSION  = 6.2-1
 MAINTAINER = WebOS Internals <support@webos-internals.org>
 
-SRC_TGZ = http://downloads.help.palm.com/opensource/3.0.0/jpegsrc.v6b.tar.gz
+SRC_TGZ = http://sources.nslu2-linux.org/sources/webos-sources/opensource/3.0.0/jpegsrc.v6b.tar.gz
 
 .PHONY: package
 package: build/.built-${VERSION}
@@ -33,7 +33,7 @@ build/.unpacked-${VERSION}: ${DL_DIR}/${NAME}-${VERSION}.tar.gz
 	mkdir -p build/armv6 build/armv7 build/i686
 	tar -C build -z -x -f $<
 	mv build/jpeg-6b build/src
-	${MAKE} SRC_FILE=http://downloads.help.palm.com/opensource/3.0.0/jpegsrc.v6b-patches.tgz \
+	${MAKE} SRC_FILE=http://sources.nslu2-linux.org/sources/webos-sources/opensource/3.0.0/jpegsrc.v6b-patches.tgz \
 		LOCAL_FILE=${NAME}-${VERSION}-patches.tgz download
 	tar -x -f ${DL_DIR}/${NAME}-${VERSION}-patches.tgz -O \
 		debian.patch ldflags.patch paths.patch | patch -d build/src -p1

--- a/toolchain/liboil/Makefile
+++ b/toolchain/liboil/Makefile
@@ -5,7 +5,7 @@ SRC_VER  = 0.3.14
 VERSION  = 0.3.14-2
 MAINTAINER = WebOS Internals <support@webos-internals.org>
 
-SRC_TGZ = http://downloads.help.palm.com/opensource/2.1.2/${NAME}-${SRC_VER}.tar.gz
+SRC_TGZ = http://sources.nslu2-linux.org/sources/webos-sources/opensource/2.1.2/${NAME}-${SRC_VER}.tar.gz
 
 .PHONY: package
 package: build/.built-${VERSION}

--- a/toolchain/libpng/Makefile
+++ b/toolchain/libpng/Makefile
@@ -5,7 +5,7 @@ SRC_VER  = 1.2.44
 VERSION  = 1.2.44-1
 MAINTAINER = WebOS Internals <support@webos-internals.org>
 
-SRC_TGZ = http://downloads.help.palm.com/opensource/3.0.0/${NAME}-${SRC_VER}.tar.gz
+SRC_TGZ = http://sources.nslu2-linux.org/sources/webos-sources/opensource/3.0.0/${NAME}-${SRC_VER}.tar.gz
 
 .PHONY: package
 package: build/.built-${VERSION}

--- a/toolchain/libsamplerate/Makefile
+++ b/toolchain/libsamplerate/Makefile
@@ -5,7 +5,7 @@ SRC_VER  = 0.1.7
 VERSION  = 0.1.7-1
 MAINTAINER = WebOS Internals <support@webos-internals.org>
 
-SRC_TGZ = http://downloads.help.palm.com/opensource/2.1.2/${NAME}-${SRC_VER}.tar.gz
+SRC_TGZ = http://sources.nslu2-linux.org/sources/webos-sources/opensource/2.1.2/${NAME}-${SRC_VER}.tar.gz
 
 .PHONY: package
 package: build/.built-${VERSION}
@@ -33,7 +33,7 @@ build/.unpacked-${VERSION}: ${DL_DIR}/${NAME}-${VERSION}.tar.gz
 	mkdir -p build/armv6 build/armv7 build/i686
 	tar -C build -z -x -f $<
 	mv build/${NAME}-${SRC_VER} build/src
-	${MAKE} SRC_FILE=http://downloads.help.palm.com/opensource/2.1.2/${NAME}-${SRC_VER}-patches.tgz \
+	${MAKE} SRC_FILE=http://sources.nslu2-linux.org/sources/webos-sources/opensource/2.1.2/${NAME}-${SRC_VER}-patches.tgz \
 		LOCAL_FILE=${NAME}-${VERSION}-patches.tgz download
 	tar -x -f ${DL_DIR}/${NAME}-${VERSION}-patches.tgz -O \
 		rc_sinc.patch | patch -d build/src -p1

--- a/toolchain/libsdl-image/Makefile
+++ b/toolchain/libsdl-image/Makefile
@@ -5,7 +5,7 @@ SRC_VER  = 1.2
 VERSION  = 1.2-2
 MAINTAINER = WebOS Internals <support@webos-internals.org>
 
-SRC_TGZ = http://downloads.help.palm.com/opensource/1.3.5/${NAME}-${SRC_VER}.tgz
+SRC_TGZ = http://sources.nslu2-linux.org/sources/webos-sources/opensource/1.3.5/${NAME}-${SRC_VER}.tgz
 
 .PHONY: package
 package: build/.built-${VERSION}
@@ -33,7 +33,7 @@ build/.unpacked-${VERSION}: ${DL_DIR}/${NAME}-${VERSION}.tar.gz
 	mkdir -p build/armv6 build/armv7 build/i686
 	tar -C build -z -x -f $<
 	mv build/${NAME}-${SRC_VER} build/src
-	${MAKE} SRC_FILE=http://downloads.help.palm.com/opensource/1.3.5/${NAME}-${SRC_VER}-patch.gz \
+	${MAKE} SRC_FILE=http://sources.nslu2-linux.org/sources/webos-sources/opensource/1.3.5/${NAME}-${SRC_VER}-patch.gz \
 		LOCAL_FILE=${NAME}-${VERSION}-patch.gz download
 	cd build/src; \
 		#zcat ../../${DL_DIR}/${NAME}-${VERSION}-patch.gz | patch -p0 ; 

--- a/toolchain/libsdl-ttf/Makefile
+++ b/toolchain/libsdl-ttf/Makefile
@@ -5,7 +5,7 @@ SRC_VER  = 1.2
 VERSION  = 1.2-2
 MAINTAINER = WebOS Internals <support@webos-internals.org>
 
-SRC_TGZ = http://downloads.help.palm.com/opensource/1.3.5/${NAME}-${SRC_VER}.tgz
+SRC_TGZ = http://sources.nslu2-linux.org/sources/webos-sources/opensource/1.3.5/${NAME}-${SRC_VER}.tgz
 
 .PHONY: package
 package: build/.built-${VERSION}
@@ -33,7 +33,7 @@ build/.unpacked-${VERSION}: ${DL_DIR}/${NAME}-${VERSION}.tar.gz
 	mkdir -p build/armv6 build/armv7 build/i686
 	tar -C build -z -x -f $<
 	mv build/${NAME}-${SRC_VER} build/src
-	${MAKE} SRC_FILE=http://downloads.help.palm.com/opensource/1.3.5/${NAME}-${SRC_VER}-patch.gz \
+	${MAKE} SRC_FILE=http://sources.nslu2-linux.org/sources/webos-sources/opensource/1.3.5/${NAME}-${SRC_VER}-patch.gz \
 		LOCAL_FILE=${NAME}-${VERSION}-patch.gz download
 	cd build/src; \
 		#zcat ../../${DL_DIR}/${NAME}-${VERSION}-patch.gz | patch -p0 ; 

--- a/toolchain/libsdl/Makefile
+++ b/toolchain/libsdl/Makefile
@@ -5,7 +5,7 @@ SRC_VER  = 1.2
 VERSION  = 1.2-2
 MAINTAINER = WebOS Internals <support@webos-internals.org>
 
-SRC_TGZ = http://downloads.help.palm.com/opensource/1.3.5/${NAME}-${SRC_VER}.tgz
+SRC_TGZ = http://sources.nslu2-linux.org/sources/webos-sources/opensource/1.3.5/${NAME}-${SRC_VER}.tgz
 
 .PHONY: package
 package: build/.built-${VERSION}
@@ -33,7 +33,7 @@ build/.unpacked-${VERSION}: ${DL_DIR}/${NAME}-${VERSION}.tar.gz
 	mkdir -p build/armv6 build/armv7 build/i686
 	tar -C build -z -x -f $<
 	mv build/${NAME}-${SRC_VER} build/src
-	${MAKE} SRC_FILE=http://downloads.help.palm.com/opensource/1.3.5/${NAME}-${SRC_VER}-patch.gz \
+	${MAKE} SRC_FILE=http://sources.nslu2-linux.org/sources/webos-sources/opensource/1.3.5/${NAME}-${SRC_VER}-patch.gz \
 		LOCAL_FILE=${NAME}-${VERSION}-patch.gz download
 	cd build/src; \
 		zcat ../../${DL_DIR}/${NAME}-${VERSION}-patch.gz | patch -p1 ; \

--- a/toolchain/libsndfile/Makefile
+++ b/toolchain/libsndfile/Makefile
@@ -1,8 +1,8 @@
 NAME     = libsndfile
 TITLE    = libsndfile
 APP_ID   = org.webosinternals.toolchain.${NAME}
-SRC_VER  = 1.0.21
-VERSION  = 1.0.21-1
+SRC_VER  = 1.0.17
+VERSION  = 1.0.17-1
 MAINTAINER = WebOS Internals <support@webos-internals.org>
 
 SRC_TGZ = http://sources.nslu2-linux.org/sources/webos-sources/opensource/3.0.0/${NAME}-${SRC_VER}.tar.gz

--- a/toolchain/libsndfile/Makefile
+++ b/toolchain/libsndfile/Makefile
@@ -5,7 +5,7 @@ SRC_VER  = 1.0.21
 VERSION  = 1.0.21-1
 MAINTAINER = WebOS Internals <support@webos-internals.org>
 
-SRC_TGZ = http://downloads.help.palm.com/opensource/3.0.0/${NAME}-${SRC_VER}.tar.gz
+SRC_TGZ = http://sources.nslu2-linux.org/sources/webos-sources/opensource/3.0.0/${NAME}-${SRC_VER}.tar.gz
 
 .PHONY: package
 package: build/.built-${VERSION}

--- a/toolchain/libspeex/Makefile
+++ b/toolchain/libspeex/Makefile
@@ -5,7 +5,7 @@ SRC_VER  = 1.2rc1
 VERSION  = 1.2rc1-2
 MAINTAINER = WebOS Internals <support@webos-internals.org>
 
-SRC_TGZ = http://downloads.help.palm.com/opensource/2.1.2/${NAME}-${SRC_VER}.tar.gz
+SRC_TGZ = http://sources.nslu2-linux.org/sources/webos-sources/opensource/2.1.2/${NAME}-${SRC_VER}.tar.gz
 
 .PHONY: package
 package: build/.built-${VERSION}
@@ -33,7 +33,7 @@ build/.unpacked-${VERSION}: ${DL_DIR}/${NAME}-${VERSION}.tar.gz
 	mkdir -p build/armv6 build/armv7 build/i686
 	tar -C build -z -x -f $<
 	mv build/${NAME}-${SRC_VER} build/src
-	${MAKE} SRC_FILE=http://downloads.help.palm.com/opensource/2.1.2/${NAME}-${SRC_VER}-patches.tgz \
+	${MAKE} SRC_FILE=http://sources.nslu2-linux.org/sources/webos-sources/opensource/2.1.2/${NAME}-${SRC_VER}-patches.tgz \
 		LOCAL_FILE=${NAME}-${VERSION}-patches.tgz download
 	tar -x -f ${DL_DIR}/${NAME}-${VERSION}-patches.tgz -O \
 		noOGG.patch | patch -d build/src -p1

--- a/toolchain/pulseaudio/Makefile
+++ b/toolchain/pulseaudio/Makefile
@@ -5,7 +5,7 @@ SRC_VER  = 0.9.22
 VERSION  = 0.9.22-1
 MAINTAINER = WebOS Internals <support@webos-internals.org>
 
-SRC_TGZ = http://downloads.help.palm.com/opensource/3.0.0/${NAME}-${SRC_VER}.tgz
+SRC_TGZ = http://sources.nslu2-linux.org/sources/webos-sources/opensource/3.0.0/${NAME}-${SRC_VER}.tgz
 
 .PHONY: package
 package: build/.built-${VERSION}

--- a/toolchain/zlib/Makefile
+++ b/toolchain/zlib/Makefile
@@ -5,7 +5,7 @@ SRC_VER  = 1.2.3
 VERSION  = 1.2.3-1
 MAINTAINER = WebOS Internals <support@webos-internals.org>
 
-SRC_BZ2 = http://downloads.help.palm.com/opensource/2.1.2/${NAME}-${SRC_VER}.tar.bz2
+SRC_BZ2 = http://sources.nslu2-linux.org/sources/webos-sources/opensource/2.1.2/${NAME}-${SRC_VER}.tar.bz2
 
 .PHONY: package
 package: build/.built-${VERSION}
@@ -33,7 +33,7 @@ build/.unpacked-${VERSION}: ${DL_DIR}/${NAME}-${VERSION}.tar.bz2
 	mkdir -p build/armv6 build/armv7 build/i686
 	tar -C build -j -x -f $<
 	mv build/${NAME}-${SRC_VER} build/src
-	${MAKE} SRC_FILE=http://downloads.help.palm.com/opensource/2.1.2/${NAME}-${SRC_VER}-patches.tgz \
+	${MAKE} SRC_FILE=http://sources.nslu2-linux.org/sources/webos-sources/opensource/2.1.2/${NAME}-${SRC_VER}-patches.tgz \
 		LOCAL_FILE=${NAME}-${VERSION}-patches.tgz download
 	tar -x -f ${DL_DIR}/${NAME}-${VERSION}-patches.tgz -O \
 		visibility.patch | patch -d build/src -p1


### PR DESCRIPTION
The downloads.help.palm.com are no longer available directly unless we sent the headers. Add the headers and to the requests. For the Palm Open Source bits we've added mirrors on nslu2-linux.org, so download them from there instead.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>